### PR TITLE
Make all solves read parameters from the relevant solver options file.

### DIFF
--- a/Programs/FTRental/vSPDSolveFTR_4.gms
+++ b/Programs/FTRental/vSPDSolveFTR_4.gms
@@ -159,6 +159,7 @@ option clear = FTRDEFICITBUSGENERATION ;
 option clear = FTRSURPLUSBUSGENERATION ;
 
 option bratio = 1;
+FTR_Model.Optfile = 1 ;
 FTR_Model.reslim = LPTimeLimit;
 FTR_Model.iterlim = LPIterationLimit;
 solve FTR_Model using lp maximizing NETBENEFIT;

--- a/Programs/vSPDmodel.gms
+++ b/Programs/vSPDmodel.gms
@@ -3,12 +3,13 @@
 * Function:             Mathematical formulation - based on the SPD formulation v9.0
 * Developed by:         Electricity Authority, New Zealand
 * Source:               https://github.com/ElectricityAuthority/vSPD
-*                       https://www.emi.ea.govt.nz/Tools/vSPD
-* Contact:              Forum: https://www.emi.ea.govt.nz/forum/
+*                       http://www.emi.ea.govt.nz/Tools/vSPD
+* Contact:              Forum: http://www.emi.ea.govt.nz/forum/
 *                       Email: emi@ea.govt.nz
-* Last modified on:     1 Oct 2019
+* Modified on:          1 Oct 2019	
 *                       New feature added: New wind offer arrangements
-*
+* Last modified on:     11 Dec 2020
+* Feature added:        Branch Reverse Rating (officially applied from 03 Feb 2021)
 *=====================================================================================
 
 $ontext
@@ -35,7 +36,6 @@ Aliases to be aware of:
   i_riskClass = riskC                       i_constraintRHS = CstrRHS
   i_riskParameter = riskPar                 i_dczone =  z, z1
 $offtext
-
 
 *===================================================================================
 * 1. Declare sets and parameters for all symbols to be loaded from daily GDX files
@@ -161,6 +161,7 @@ Parameters
   i_tradePeriodHVDCBranch(tp,br)                                    'HVDC branch indicator for the different trading periods'
   i_tradePeriodBranchParameter(tp,br,i_branchParameter)             'Branch resistance, reactance, fixed losses and number of loss tranches for the different time periods'
   i_tradePeriodBranchCapacity(tp,br)                                'Branch capacity for the different trading periods in MW'
+  i_tradePeriodBranchCapacityDirected(tp,br,fd)                     'Branch directed capacity for the different trading periods in MW (Branch Reverse Ratings)'
   i_tradePeriodBranchOpenStatus(tp,br)                              'Branch open status for the different trading periods, 1 = Open'
   i_noLossBranch(los,i_lossParameter)                               'Loss parameters for no loss branches'
   i_AClossBranch(los,i_lossParameter)                               'Loss parameters for AC loss branches'
@@ -250,8 +251,9 @@ Scalars
   MIPtimeLimit                             'CPU seconds allowed for MIP solves'
   MIPiterationLimit                        'Iteration limit allowed for MIP solves'
   MIPoptimality
-  disconnectedNodePriceCorrection
-  tradePeriodReports
+  disconnectedNodePriceCorrection          'Flag to apply price correction methods to disconnected node'
+  tradePeriodReports                       'Specify 1 for reports at trading period level, 0 otherwise , no longer used?'
+
 * External loss model from Transpower
   lossCoeff_A                       / 0.3101 /
   lossCoeff_C                       / 0.14495 /
@@ -303,7 +305,7 @@ Sets
   HVDCHalfPoles(tp,br)                                              'Connection DC Pole 1 between AC and DC systems at Benmore and Haywards'
   HVDCpoleDirection(tp,br,fd)                                       'Direction defintion for HVDC poles S->N : Forward and N->S : Southward'
   ACBranch(tp,br)                                                   'AC branches defined for the current trading period'
-  validLossSegment(tp,br,los)                                       'Valid loss segments for a branch'
+  validLossSegment(tp,br,los,fd)                                    'Valid loss segments for a branch'
   lossBranch(tp,br)                                                 'Subset of branches that have non-zero loss factors'
 * Mapping set of branches to HVDC pole
   HVDCpoleBranchMap(pole,br)                                        'Mapping of HVDC  branch to pole number'
@@ -379,17 +381,17 @@ Parameters
   PurchaseBidILRMW(tp,bd,trdBlk,resC)                               'Purchase bid ILR block in MW for the different reserve classes'
   PurchaseBidILRPrice(tp,bd,trdBlk,resC)                            'Purchase bid ILR price in $/MW for the different reserve classes'
 * Network
-  branchCapacity(tp,br)                                             'MW capacity of a branch for the current trading period'
+  branchCapacity(tp,br,fd)                                          'MW capacity of a branch for the current trading period'
   branchResistance(tp,br)                                           'Resistance of the a branch for the current trading period in per unit'
   branchSusceptance(tp,br)                                          'Susceptance (inverse of reactance) of a branch for the current trading period in per unit'
   branchFixedLoss(tp,br)                                            'Fixed loss of the a branch for the current trading period in MW'
   branchLossBlocks(tp,br)                                           'Number of blocks in the loss curve for the a branch in the current trading period'
-  lossSegmentMW(tp,br,los)                                          'MW capacity of each loss segment'
-  lossSegmentFactor(tp,br,los)                                      'Loss factor of each loss segment'
-  ACBranchLossMW(tp,br,los)                                         'MW element of the loss segment curve in MW'
-  ACBranchLossFactor(tp,br,los)                                     'Loss factor element of the loss segment curve'
-  HVDCBreakPointMWFlow(tp,br,bp)                                    'Value of power flow on the HVDC at the break point'
-  HVDCBreakPointMWLoss(tp,br,bp)                                    'Value of variable losses on the HVDC at the break point'
+  lossSegmentMW(tp,br,los,fd)                                       'MW capacity of each loss segment'
+  lossSegmentFactor(tp,br,los,fd)                                   'Loss factor of each loss segment'
+  ACBranchLossMW(tp,br,los,fd)                                      'MW element of the loss segment curve in MW'
+  ACBranchLossFactor(tp,br,los,fd)                                  'Loss factor element of the loss segment curve'
+  HVDCBreakPointMWFlow(tp,br,bp,fd)                                 'Value of power flow on the HVDC at the break point'
+  HVDCBreakPointMWLoss(tp,br,bp,fd)                                 'Value of variable losses on the HVDC at the break point'
   NodeBusAllocationFactor(tp,n,b)                                   'Allocation factor of market node to bus for the current trade period'
   BusElectricalIsland(tp,b)                                         'Bus electrical island status for the current trade period (0 = Dead)'
 * Flag to allow roundpower on the HVDC link
@@ -878,23 +880,23 @@ PurchaseBidDefintion(bid(currTP,bd))..
 HVDClinkMaximumFlow(HVDClink(currTP,br)) $ useHVDCbranchLimits ..
   HVDCLINKFLOW(HVDClink)
 =l=
-  branchCapacity(HVDClink)
+  sum[ fd $ ( ord(fd)=1 ), branchCapacity(HVDClink,fd) ]
   ;
 
 * Definition of losses on the HVDC link (3.2.1.2)
 HVDClinkLossDefinition(HVDClink(currTP,br))..
   HVDCLINKLOSSES(HVDClink)
 =e=
-  sum[ validLossSegment(HVDClink,bp)
-     , HVDCBreakPointMWLoss(HVDClink,bp) * LAMBDA(HVDClink,bp) ]
+  sum[ validLossSegment(HVDClink,bp,fd)
+     , HVDCBreakPointMWLoss(HVDClink,bp,fd) * LAMBDA(HVDClink,bp) ]
   ;
 
 * Definition of MW flow on the HVDC link (3.2.1.3)
 HVDClinkFlowDefinition(HVDClink(currTP,br))..
   HVDCLINKFLOW(HVDClink)
 =e=
-  sum[ validLossSegment(HVDClink,bp)
-  , HVDCBreakPointMWFlow(HVDClink,bp) * LAMBDA(HVDClink,bp) ]
+  sum[ validLossSegment(HVDClink,bp,fd)
+  , HVDCBreakPointMWFlow(HVDClink,bp,fd) * LAMBDA(HVDClink,bp) ]
   ;
 
 * Definition of the integer HVDC link flow variable (3.8.2a)
@@ -939,7 +941,7 @@ HVDClinkFlowIntegerDefinition4(currTP,pole,fd) $ { UseBranchFlowMIP(currTP) and
 
 * Definition of weighting factor (3.2.1.4)
 LambdaDefinition(HVDClink(currTP,br))..
-  sum(validLossSegment(HVDClink,bp), LAMBDA(HVDClink,bp))
+  sum(validLossSegment(HVDClink,bp,fd), LAMBDA(HVDClink,bp))
 =e=
   1
   ;
@@ -947,14 +949,15 @@ LambdaDefinition(HVDClink(currTP,br))..
 * Definition of weighting factor when branch integer constraints are needed (3.8.3a)
 LambdaIntegerDefinition1(HVDClink(currTP,br)) $ { UseBranchFlowMIP(currTP) and
                                                   resolveHVDCnonPhysicalLosses }..
-  sum[ validLossSegment(HVDClink,bp), LAMBDAINTEGER(HVDClink,bp) ]
+  sum[ validLossSegment(HVDClink,bp,fd), LAMBDAINTEGER(HVDClink,bp) ]
 =e=
   1
   ;
 
 * Definition of weighting factor when branch integer constraints are needed (3.8.3b)
-LambdaIntegerDefinition2(validLossSegment(HVDClink(currTP,br),bp))
-  $ { UseBranchFlowMIP(currTP) and resolveHVDCnonPhysicalLosses }..
+LambdaIntegerDefinition2(HVDClink(currTP,br),bp)
+  $ { UseBranchFlowMIP(currTP) and resolveHVDCnonPhysicalLosses
+  and sum[ fd $ validLossSegment(HVDClink,bp,fd), 1] }..
   LAMBDAINTEGER(HVDClink,bp)
 =e=
   LAMBDA(HVDClink,bp)
@@ -1015,11 +1018,11 @@ ACnodeNetInjectionDefinition2(ACBus(currTP,b))..
 + DEFICITBUSGENERATION(currTP,b) - SURPLUSBUSGENERATION(currTP,b)
   ;
 
-* Maximum flow on the AC branch (3.3.1.3)
+* Maximum flow on the AC branch (3.3.1.3) - Modified for BranchcReverseRatings
 ACBranchMaximumFlow(ACbranch(currTP,br),fd) $ useACbranchLimits..
   ACBRANCHFLOWDIRECTED(ACBranch,fd) - SURPLUSBRANCHFLOW(ACBranch)
 =l=
-  branchCapacity(ACBranch)
+  branchCapacity(ACBranch,fd)
   ;
 
 * Relationship between directed and undirected branch flow variables (3.3.1.4)
@@ -1039,33 +1042,34 @@ LinearLoadFlow(ACBranch(currTP,br))..
        , ACNODEANGLE(currTP,frB) - ACNODEANGLE(currTP,toB) ]
   ;
 
-* Limit on each AC branch flow block (3.3.1.6)
-ACBranchBlockLimit(validLossSegment(ACBranch(currTP,br),los),fd)..
+* Limit on each AC branch flow block (3.3.1.6) - Modified for BranchcReverseRatings
+ACBranchBlockLimit(validLossSegment(ACBranch(currTP,br),los,fd))..
   ACBRANCHFLOWBLOCKDIRECTED(ACBranch,los,fd)
 =l=
-  ACBranchLossMW(ACBranch,los)
+  ACBranchLossMW(ACBranch,los,fd)
   ;
 
 * Composition of the directed branch flow from the block branch flow (3.3.1.7)
 ACDirectedBranchFlowDefinition(ACBranch(currTP,br),fd)..
   ACBRANCHFLOWDIRECTED(ACBranch,fd)
 =e=
-  sum[ validLossSegment(ACBranch,los)
+  sum[ validLossSegment(ACBranch,los,fd)
      , ACBRANCHFLOWBLOCKDIRECTED(ACBranch,los,fd) ]
   ;
 
-* Calculation of the losses in each loss segment (3.3.1.8)
-ACBranchLossCalculation(validLossSegment(ACBranch(currTP,br),los),fd)..
+* Calculation of the losses in each loss segment (3.3.1.8) - Modified for BranchcReverseRatings
+ACBranchLossCalculation(validLossSegment(ACBranch(currTP,br),los,fd))..
   ACBRANCHLOSSESBLOCKDIRECTED(ACBranch,los,fd)
 =e=
-  ACBRANCHFLOWBLOCKDIRECTED(ACBranch,los,fd) * ACBranchLossFactor(ACBranch,los)
+  ACBRANCHFLOWBLOCKDIRECTED(ACBranch,los,fd)
+  * ACBranchLossFactor(ACBranch,los,fd)
   ;
 
 * Composition of the directed branch losses from the block branch losses (3.3.1.9)
 ACDirectedBranchLossDefinition(ACBranch(currTP,br),fd)..
   ACBRANCHLOSSESDIRECTED(ACBranch,fd)
 =e=
-  sum[ validLossSegment(ACBranch,los)
+  sum[ validLossSegment(ACBranch,los,fd)
      , ACBRANCHLOSSESBLOCKDIRECTED(ACBranch,los,fd) ]
   ;
 
@@ -1392,7 +1396,7 @@ ReverseReserveLimitInReserveZone(currTP,ild,resC,rd,z)
 ZeroReserveInNoReserveZone(currTP,ild,resC,z)
   $ { reserveShareEnabled(currTP,resC) and (ord(z) = 2) }..
   Sum[ rd $ (ord(rd) = 2), RESERVESHARERECEIVED(currTP,ild,resC,rd) ]
-+ Sum[ rd $ (ord(rd) = 1), RESERVESHARESENT(currTP,ild,resC,rd) ]${reserveRoundPower(currTP,resC) = 0}
++ Sum[ rd $ (ord(rd) = 1), RESERVESHARESENT(currTP,ild,resC,rd) ] $ {reserveRoundPower(currTP,resC) = 0}
 =l=
   BigM * [ 1 - INZONE(currTP,ild,resC,z) ]
   ;

--- a/Programs/vSPDsolve.gms
+++ b/Programs/vSPDsolve.gms
@@ -4,13 +4,17 @@
 *                       the model
 * Developed by:         Electricity Authority, New Zealand
 * Source:               https://github.com/ElectricityAuthority/vSPD
-*                       https://www.emi.ea.govt.nz/Tools/vSPD
-* Contact:              Forum: https://www.emi.ea.govt.nz/forum/
+*                       http://www.emi.ea.govt.nz/Tools/vSPD
+* Contact:              Forum: http://www.emi.ea.govt.nz/forum/
 *                       Email: emi@ea.govt.nz
-* Modified on:          1 Oct 2019
-*                       New feature added: new wind offer arrangements
-* Last modified on:     11 Nov 2020
-*                       Replacing invalid bus prices after SOS1 (6.1.3)
+* Modified on:          1 Oct 2019	
+*                       New feature added: new wind offer arrangements	
+* Modified on:          11 Nov 2020	
+*                       Replacing invalid bus prices after SOS1 (6.1.3)	
+* Last modified on:     11 Dec 2020
+*                       From 11 Dec 2020, GDX input file have i_tradePeriodBranchCapacityDirected
+*                       and i_tradePeriodReverseRatingsApplied symbols	   
+*                       Applying branch reverse rating	s only when i_tradePeriodReverseRatingsApplied = 1
 *
 *=====================================================================================
 
@@ -165,8 +169,8 @@ Sets
 * Unmmaped bus defificit temporary sets
   unmappedDeficitBus(dt,b)                            'List of buses that have deficit generation (price) and are not mapped to any pnode'
   changedDeficitBus(dt,b)                             'List of buses that have deficit generation added from unmapped deficit bus'
-* TN - Replacing invalid prices after SOS1
-  vSPD_SOS1_Solve(tp)                                'Flag period that is resolved using SOS1'
+* TN - Replacing invalid prices after SOS1	
+  vSPD_SOS1_Solve(tp)                                 'Flag period that is resolved using SOS1'  
   ;
 
 Parameters
@@ -181,7 +185,7 @@ Parameters
   northHVDC(tp)                                       'HVDC MW sent from from SI to NI'
   southHVDC(tp)                                       'HVDC MW sent from from NI to SI'
   nonPhysicalLossExist(tp,br)                         'Flag to indicate if non-physical losses exist on branch: 1 = Yes'
-  manualBranchSegmentMWFlow(tp,br,los)                'Manual calculation of the branch loss segment MW flow'
+  manualBranchSegmentMWFlow(tp,br,los,fd)             'Manual calculation of the branch loss segment MW flow'
   manualLossCalculation(tp,br)                        'MW losses calculated manually from the solution for each loss branch'
   HVDChalfPoleSouthFlow(tp)                           'Flag to indicate if south flow on HVDC halfpoles'
   type1MixedConstraintLimit2Violation(tp, t1MixCstr)  'Type 1 mixed constraint MW violaton of the alternate limit value'
@@ -218,10 +222,12 @@ Parameters
   scaledislandGWAP(tp,ild)
   scaledscarcityAreaGWAP(tp,sarea)
 * Unmmaped bus defificit temporary parameters
-  temp_busDeficit_TP(dt,b)                            'Bus deficit violation for each trade period'
-* TN - Replacing invalid prices after SOS1
-  busSOSinvalid(tp,b)                                 'Buses with invalid bus prices after SOS1 solve'
+  temp_busDeficit_TP(dt,b) 'Bus deficit violation for each trade period'
+* TN - Replacing invalid prices after SOS1	
+  busSOSinvalid(tp,b)                                 'Buses with invalid bus prices after SOS1 solve'	
   numberofbusSOSinvalid(tp)                           'Number of buses with invalid bus prices after SOS1 solve --> used to check if invalid prices can be improved (numberofbusSOSinvalid reduces after each iteration) '
+* TN - Flag to apply branch reverse ratings
+  reverseRatingsApplied(tp)  
   ;
 
 Sets
@@ -604,47 +610,63 @@ else
 
 * Scarcity pricing scheme for reserve available from 27 May 2014
 if(inputGDXGDate >= jdate(2014,5,27),
-  execute_load i_tradePeriodVROfferMax, i_tradePeriodVROfferPrice ;
+    execute_load i_tradePeriodVROfferMax, i_tradePeriodVROfferPrice ;
 else
-  i_tradePeriodVROfferMax(tp,ild,resC) = 0 ;
-  i_tradePeriodVROfferPrice(tp,ild,resC) = 0 ;
+    i_tradePeriodVROfferMax(tp,ild,resC) = 0 ;
+    i_tradePeriodVROfferPrice(tp,ild,resC) = 0 ;
 ) ;
 
 
 * National market for IR effective date 20 Oct 2016
 if (inputGDXGDate >= jdate(2016,10,20),
-  execute_load
-  reserveRoundPower     = i_tradePeriodReserveRoundPower
-  reserveShareEnabled   = i_tradePeriodReserveSharing
-  modulationRiskClass   = i_tradePeriodModulationRisk
-  roundPower2MonoLevel  = i_tradePeriodRoundPower2Mono
-  bipole2MonoLevel      = i_tradePeriodBipole2Mono
-  monopoleMinimum       = i_tradePeriodReserveSharingPoleMin
-  HVDCControlBand       = i_tradePeriodHVDCcontrolBand
-  HVDClossScalingFactor = i_tradePeriodHVDClossScalingFactor
-  sharedNFRfactor       = i_tradePeriodSharedNFRfactor
-  sharedNFRLoadOffset   = i_tradePeriodSharedNFRLoadOffset
-  effectiveFactor       = i_tradePeriodReserveEffectiveFactor
-  RMTreserveLimitTo     = i_tradePeriodRMTreserveLimit
-  rampingConstraint     = i_tradePeriodRampingConstraint
+    execute_load
+    reserveRoundPower     = i_tradePeriodReserveRoundPower
+    reserveShareEnabled   = i_tradePeriodReserveSharing
+    modulationRiskClass   = i_tradePeriodModulationRisk
+    roundPower2MonoLevel  = i_tradePeriodRoundPower2Mono
+    bipole2MonoLevel      = i_tradePeriodBipole2Mono
+    monopoleMinimum       = i_tradePeriodReserveSharingPoleMin
+    HVDCControlBand       = i_tradePeriodHVDCcontrolBand
+    HVDClossScalingFactor = i_tradePeriodHVDClossScalingFactor
+    sharedNFRfactor       = i_tradePeriodSharedNFRfactor
+    sharedNFRLoadOffset   = i_tradePeriodSharedNFRLoadOffset
+    effectiveFactor       = i_tradePeriodReserveEffectiveFactor
+    RMTreserveLimitTo     = i_tradePeriodRMTreserveLimit
+    rampingConstraint     = i_tradePeriodRampingConstraint
   ;
 else
-  reserveRoundPower(tp,resC)         = 0    ;
-  reserveShareEnabled(tp,resC)       = 0    ;
-  modulationRiskClass(tp,riskC)      = 0    ;
-  roundPower2MonoLevel(tp)           = 0    ;
-  bipole2MonoLevel(tp)               = 0    ;
-  MonopoleMinimum(tp)                = 0    ;
-  HVDCControlBand(tp,fd)             = 0    ;
-  HVDClossScalingFactor(tp)          = 0    ;
-  sharedNFRfactor(tp)                = 0    ;
-  sharedNFRloadOffset(tp,ild)        = 0    ;
-  effectiveFactor(tp,ild,resC,riskC) = 0    ;
-  RMTreserveLimitTo(tp,ild,resC)     = 0    ;
-  rampingConstraint(tp,brCstr)       = no   ;
+    reserveRoundPower(tp,resC)         = 0    ;
+    reserveShareEnabled(tp,resC)       = 0    ;
+    modulationRiskClass(tp,riskC)      = 0    ;
+    roundPower2MonoLevel(tp)           = 0    ;
+    bipole2MonoLevel(tp)               = 0    ;
+    MonopoleMinimum(tp)                = 0    ;
+    HVDCControlBand(tp,fd)             = 0    ;
+    HVDClossScalingFactor(tp)          = 0    ;
+    sharedNFRfactor(tp)                = 0    ;
+    sharedNFRloadOffset(tp,ild)        = 0    ;
+    effectiveFactor(tp,ild,resC,riskC) = 0    ;
+    RMTreserveLimitTo(tp,ild,resC)     = 0    ;
+    rampingConstraint(tp,brCstr)       = no   ;
 ) ;
 
 UseShareReserve = 1 $ sum[ (tp,resC), reserveShareEnabled(tp,resC)] ;
+
+* Branch Reverse Ratings planned to go-live on 03/Feb/2021 (this will be flagged in GDX using i_tradePeriodReverseRatingsApplied)
+* From 11 Dec 2020, GDX file will have i_tradePeriodBranchCapacityDirected and i_tradePeriodReverseRatingsApplied symbols
+if (inputGDXGDate >= jdate(2020,12,11),
+    execute_load i_tradePeriodBranchCapacityDirected;
+    execute_load reverseRatingsApplied = i_tradePeriodReverseRatingsApplied;
+    
+    i_tradePeriodBranchCapacityDirected(tp,br,'backward') $ (reverseRatingsApplied(tp)=0)
+        = i_tradePeriodBranchCapacityDirected(tp,br,'forward');
+            
+else
+    i_tradePeriodBranchCapacityDirected(tp,br,fd)
+        = i_tradePeriodBranchCapacity(tp,br) ;
+) ;
+
+
 
 *=====================================================================================
 * 4. Input data overrides - declare and apply (include vSPDoverrides.gms)
@@ -927,10 +949,12 @@ nodeDemand(node(tp,n))
 * Branch is defined if there is a defined terminal bus, it has a non-zero
 * capacity and is closed for that trade period
 branch(tp,br) $ { (not i_tradePeriodBranchOpenStatus(tp,br)) and
-                  i_tradePeriodBranchCapacity(tp,br)         and
+                  sum[ fd, i_tradePeriodBranchCapacityDirected(tp,br,fd)] and
                   sum[ (b,b1) $ { bus(tp,b) and bus(tp,b1) and
                                   i_tradePeriodBranchDefn(tp,br,b,b1) }, 1 ]
                 } = yes ;
+
+
 
 branchBusDefn(branch,b,b1) $ i_tradePeriodBranchDefn(branch,b,b1)    = yes ;
 branchBusConnect(branch,b) $ sum[b1 $ branchBusDefn(branch,b,b1), 1] = yes ;
@@ -994,9 +1018,13 @@ nodeBusAllocationFactor(tp,n,b) $ { node(tp,n) and bus(tp,b) }
 * Flag to allow roundpower on the HVDC link
 allowHVDCroundpower(tp) = i_tradePeriodAllowHVDCroundpower(tp) ;
 
-* Allocate the input branch parameters to the defined model parameters
-branchCapacity(branch) = i_tradePeriodBranchCapacity(branch) ;
+* Allocate the input branch parameters to the defined branchCapacity
+branchCapacity(branch,fd)
+    = i_tradePeriodBranchCapacityDirected(branch,fd) ;
+* HVDC Links do not have reverse capacity
+branchCapacity(HVDClink,fd) $ ( ord(fd) = 2 ) = 0 ;
 
+* Allocate the input branch parameters to the defined branchResistance
 branchResistance(branch)
     = sum[ i_branchParameter $ (ord(i_branchParameter) = 1)
          , i_tradePeriodBranchParameter(branch,i_branchParameter) ] ;
@@ -1033,150 +1061,155 @@ branchFixedLoss(HVDClink)  $ (not useHVDClossModel) = 0 ;
 * and the resistance is in p.u.
 
 * Loss branches with 0 loss blocks
-LossSegmentMW(branch,los)
+lossSegmentMW(branch,los,fd)
     $ { (branchLossBlocks(branch) = 0) and (ord(los) = 1) }
-    = branchCapacity(branch) ;
+    = branchCapacity(branch,fd) ;
 
-LossSegmentFactor(branch,los)
+LossSegmentFactor(branch,los,fd)
     $ { (branchLossBlocks(branch) = 0) and (ord(los) = 1) }
     = 0 ;
 
 * Loss branches with 1 loss blocks
-LossSegmentMW(branch,los)
+LossSegmentMW(branch,los,fd)
     $ { (branchLossBlocks(branch) = 1) and (ord(los) = 1) }
     = maxFlowSegment ;
 
-LossSegmentFactor(branch,los)
+LossSegmentFactor(branch,los,fd)
     $ { (branchLossBlocks(branch) = 1) and (ord(los) = 1) }
-    = 0.01 * branchResistance(branch) * branchCapacity(branch) ;
+    = 0.01 * branchResistance(branch) * branchCapacity(branch,fd) ;
 
 * Loss branches with 3 loss blocks
 loop( branch $ (branchLossBlocks(branch) = 3),
 *   Segment 1
-    LossSegmentMW(branch,los) $ (ord(los) = 1)
-        = lossCoeff_A * branchCapacity(branch) ;
+    LossSegmentMW(branch,los,fd) $ (ord(los) = 1)
+        = lossCoeff_A * branchCapacity(branch,fd) ;
 
-    LossSegmentFactor(branch,los) $ (ord(los) = 1)
+    LossSegmentFactor(branch,los,fd) $ (ord(los) = 1)
         = 0.01 * 0.75 * lossCoeff_A
-        * branchResistance(branch) * branchCapacity(branch) ;
+        * branchResistance(branch) * branchCapacity(branch,fd) ;
 
 *   Segment 2
-    LossSegmentMW(branch,los) $ (ord(los) = 2)
-        = (1-lossCoeff_A) * branchCapacity(branch) ;
+    LossSegmentMW(branch,los,fd) $ (ord(los) = 2)
+        = (1-lossCoeff_A) * branchCapacity(branch,fd) ;
 
-    LossSegmentFactor(branch,los) $ (ord(los) = 2)
-        = 0.01 * branchResistance(branch) * branchCapacity(branch) ;
+    LossSegmentFactor(branch,los,fd) $ (ord(los) = 2)
+        = 0.01 * branchResistance(branch) * branchCapacity(branch,fd) ;
 
 *   Segment 3
-    LossSegmentMW(branch,los) $ (ord(los) = 3)
+    LossSegmentMW(branch,los,fd) $ (ord(los) = 3)
         = maxFlowSegment ;
 
-    LossSegmentFactor(branch,los) $ (ord(los) = 3)
+    LossSegmentFactor(branch,los,fd) $ (ord(los) = 3)
         = 0.01 * (2 - (0.75*lossCoeff_A))
-        * branchResistance(branch) * branchCapacity(branch) ;
+        * branchResistance(branch) * branchCapacity(branch,fd) ;
 );
 
 * Loss branches with 6 loss blocks
 loop( branch $ (branchLossBlocks(branch) = 6),
 *   Segment 1
-    LossSegmentMW(branch,los) $ (ord(los) = 1)
-        = lossCoeff_C  * branchCapacity(branch) ;
+    LossSegmentMW(branch,los,fd) $ (ord(los) = 1)
+        = lossCoeff_C  * branchCapacity(branch,fd) ;
 
-    LossSegmentFactor(branch,los) $ (ord(los) = 1)
+    LossSegmentFactor(branch,los,fd) $ (ord(los) = 1)
         = 0.01 * 0.75 * lossCoeff_C
-        * branchResistance(branch) * branchCapacity(branch) ;
+        * branchResistance(branch) * branchCapacity(branch,fd) ;
 
 *   Segment 2
-    LossSegmentMW(branch,los) $ (ord(los) = 2)
-        = lossCoeff_D * branchCapacity(branch) ;
+    LossSegmentMW(branch,los,fd) $ (ord(los) = 2)
+        = lossCoeff_D * branchCapacity(branch,fd) ;
 
-    LossSegmentFactor(branch,los) $ (ord(los) = 2)
+    LossSegmentFactor(branch,los,fd) $ (ord(los) = 2)
         = 0.01 * lossCoeff_E
-        * branchResistance(branch) * branchCapacity(branch) ;
+        * branchResistance(branch) * branchCapacity(branch,fd) ;
 
 *   Segment 3
-    LossSegmentMW(branch,los) $ (ord(los) = 3)
-        = 0.5 * branchCapacity(branch) ;
+    LossSegmentMW(branch,los,fd) $ (ord(los) = 3)
+        = 0.5 * branchCapacity(branch,fd) ;
 
-    LossSegmentFactor(branch,los) $ (ord(los) = 3)
+    LossSegmentFactor(branch,los,fd) $ (ord(los) = 3)
         = 0.01 * lossCoeff_F
-        * branchResistance(branch) * branchCapacity(branch) ;
+        * branchResistance(branch) * branchCapacity(branch,fd) ;
 
 *   Segment 4
-    LossSegmentMW(branch,los) $ (ord(los) = 4)
-        = (1 - lossCoeff_D) * branchCapacity(branch) ;
+    LossSegmentMW(branch,los,fd) $ (ord(los) = 4)
+        = (1 - lossCoeff_D) * branchCapacity(branch,fd) ;
 
-    LossSegmentFactor(branch,los) $ (ord(los) = 4)
+    LossSegmentFactor(branch,los,fd) $ (ord(los) = 4)
         = 0.01 * (2 - lossCoeff_F)
-        * branchResistance(branch) * branchCapacity(branch) ;
+        * branchResistance(branch) * branchCapacity(branch,fd) ;
 
 *   Segment 5
-    LossSegmentMW(branch,los) $ (ord(los) = 5)
-        = (1 - lossCoeff_C) * branchCapacity(branch) ;
+    LossSegmentMW(branch,los,fd) $ (ord(los) = 5)
+        = (1 - lossCoeff_C) * branchCapacity(branch,fd) ;
 
-    LossSegmentFactor(branch,los) $ (ord(los) = 5)
+    LossSegmentFactor(branch,los,fd) $ (ord(los) = 5)
         = 0.01 * (2 - lossCoeff_E)
-        * branchResistance(branch) * branchCapacity(branch) ;
+        * branchResistance(branch) * branchCapacity(branch,fd) ;
 
 *   Segment 6
-    LossSegmentMW(branch,los) $ (ord(los) = 6)
+    LossSegmentMW(branch,los,fd) $ (ord(los) = 6)
         = maxFlowSegment ;
 
-    LossSegmentFactor(branch,los) $ (ord(los) = 6)
+    LossSegmentFactor(branch,los,fd) $ (ord(los) = 6)
         = 0.01 * (2 - (0.75*lossCoeff_C))
-        * branchResistance(branch) * branchCapacity(branch) ;
+        * branchResistance(branch) * branchCapacity(branch,fd) ;
 ) ;
+
+* HVDC does not have backward flow --> No loss segment for backward flow
+LossSegmentMW(HVDClink,los,fd) $ (ord(fd) = 2) = 0;
+LossSegmentFactor(HVDClink,los,fd) $ (ord(fd) = 2) = 0;
+
 
 * Valid loss segment for a branch is defined as a loss segment that
 * has a non-zero LossSegmentMW or a non-zero LossSegmentFactor.
-validLossSegment(branch,los) = yes $ { (ord(los) = 1) or
-                                       LossSegmentMW(branch,los) or
-                                       LossSegmentFactor(branch,los) } ;
+validLossSegment(branch,los,fd) = yes $ { (ord(los) = 1) or
+                                          LossSegmentMW(branch,los,fd) or
+                                          LossSegmentFactor(branch,los,fd) } ;
 
 * HVDC loss model requires at least two loss segments and
 * an additional loss block due to cumulative loss formulation
-validLossSegment(HVDClink,los)
+validLossSegment(HVDClink,los,fd)
     $ { (branchLossBlocks(HVDClink) <= 1) and (ord(los) = 2) } = yes ;
 
-validLossSegment(HVDClink,los)
+validLossSegment(HVDClink,los,fd)
     $ { (branchLossBlocks(HVDClink) > 1) and
         (ord(los) = (branchLossBlocks(HVDClink) + 1)) and
-        (sum[ los1, LossSegmentMW(HVDClink,los1)
-                  + LossSegmentFactor(HVDClink,los1) ] > 0)
+        (sum[ los1, LossSegmentMW(HVDClink,los1,fd)
+                  + LossSegmentFactor(HVDClink,los1,fd) ] > 0)
       } = yes ;
 
 * branches that have non-zero loss factors
-LossBranch(branch) $ sum[ los, LossSegmentFactor(branch,los) ] = yes ;
+LossBranch(branch) $ sum[ (los,fd), LossSegmentFactor(branch,los,fd) ] = yes ;
 
 * Create AC branch loss segments
-ACbranchLossMW(ACbranch,los)
-    $ { validLossSegment(ACbranch,los) and (ord(los) = 1) }
-    = LossSegmentMW(ACbranch,los) ;
+ACbranchLossMW(ACbranch,los,fd)
+    $ { validLossSegment(ACbranch,los,fd) and (ord(los) = 1) }
+    = LossSegmentMW(ACbranch,los,fd) ;
 
-ACbranchLossMW(ACbranch,los)
-    $ { validLossSegment(ACbranch,los) and (ord(los) > 1) }
-    = LossSegmentMW(ACbranch,los) - LossSegmentMW(ACbranch,los-1) ;
+ACbranchLossMW(ACbranch,los,fd)
+    $ { validLossSegment(ACbranch,los,fd) and (ord(los) > 1) }
+    = LossSegmentMW(ACbranch,los,fd) - LossSegmentMW(ACbranch,los-1,fd) ;
 
-ACbranchLossFactor(ACbranch,los)
-    $ validLossSegment(ACbranch,los) = LossSegmentFactor(ACbranch,los) ;
+ACbranchLossFactor(ACbranch,los,fd)
+    $ validLossSegment(ACbranch,los,fd) = LossSegmentFactor(ACbranch,los,fd) ;
 
 * Create HVDC loss break points
-HVDCBreakPointMWFlow(HVDClink,bp) $ (ord(bp) = 1) = 0 ;
-HVDCBreakPointMWLoss(HVDClink,bp) $ (ord(bp) = 1) = 0 ;
+HVDCBreakPointMWFlow(HVDClink,bp,fd) $ (ord(bp) = 1) = 0 ;
+HVDCBreakPointMWLoss(HVDClink,bp,fd) $ (ord(bp) = 1) = 0 ;
 
-HVDCBreakPointMWFlow(HVDClink,bp)
-    $ { validLossSegment(HVDClink,bp) and (ord(bp) > 1) }
-    = LossSegmentMW(HVDClink,bp-1) ;
+HVDCBreakPointMWFlow(HVDClink,bp,fd)
+    $ { validLossSegment(HVDClink,bp,fd) and (ord(bp) > 1) }
+    = LossSegmentMW(HVDClink,bp-1,fd) ;
 
-HVDCBreakPointMWLoss(HVDClink,bp)
-    $ { validLossSegment(HVDClink,bp) and (ord(bp) = 2) }
-    =  LossSegmentMW(HVDClink,bp-1) * LossSegmentFactor(HVDClink,bp-1)  ;
+HVDCBreakPointMWLoss(HVDClink,bp,fd)
+    $ { validLossSegment(HVDClink,bp,fd) and (ord(bp) = 2) }
+    =  LossSegmentMW(HVDClink,bp-1,fd) * LossSegmentFactor(HVDClink,bp-1,fd) ;
 
 loop( (HVDClink(branch),bp) $ (ord(bp) > 2),
-    HVDCBreakPointMWLoss(branch,bp) $ validLossSegment(branch,bp)
-        = LossSegmentFactor(branch,bp-1)
-        * [ LossSegmentMW(branch,bp-1) - LossSegmentMW(branch,bp-2) ]
-        + HVDCBreakPointMWLoss(branch,bp-1) ;
+    HVDCBreakPointMWLoss(branch,bp,fd) $ validLossSegment(branch,bp,fd)
+        = LossSegmentFactor(branch,bp-1,fd)
+        * [ LossSegmentMW(branch,bp-1,fd) - LossSegmentMW(branch,bp-2,fd) ]
+        + HVDCBreakPointMWLoss(branch,bp-1,fd) ;
 ) ;
 
 * Initialise branch constraint data for the current trading period
@@ -1261,10 +1294,11 @@ bipoleConstraint(tp,ild,brCstr)
                        } = yes ;
 
 monoPoleCapacity(tp,ild,br)
-    = Sum[ b $ { BusIsland(tp,b,ild)
-             and HVDCPoles(tp,br)
-             and HVDClinkSendingBus(tp,br,b)
-               }, branchCapacity(tp,br) ] ;
+    = Sum[ (b,fd) $ { BusIsland(tp,b,ild)
+                  and HVDCPoles(tp,br)
+                  and HVDClinkSendingBus(tp,br,b)
+                  and ( ord(fd) = 1 )
+                    }, branchCapacity(tp,br,fd) ] ;
 
 monoPoleCapacity(tp,ild,br)
     $ Sum[ brCstr $ monopoleConstraint(tp,ild,brCstr,br), 1]
@@ -1272,7 +1306,8 @@ monoPoleCapacity(tp,ild,br)
           , branchConstraintLimit(tp,brCstr) ];
 
 monoPoleCapacity(tp,ild,br)
-    = Min( monoPoleCapacity(tp,ild,br), branchCapacity(tp,br) );
+    = Min( monoPoleCapacity(tp,ild,br),
+           sum[ fd $ ( ord(fd) = 1 ), branchCapacity(tp,br,fd) ] );
 
 biPoleCapacity(tp,ild)
     $ Sum[ brCstr $ bipoleConstraint(tp,ild,brCstr), 1]
@@ -1281,8 +1316,10 @@ biPoleCapacity(tp,ild)
 
 biPoleCapacity(tp,ild)
     $ { Sum[ brCstr $ bipoleConstraint(tp,ild,brCstr), 1] = 0 }
-    = Sum[ (b,br) $ { BusIsland(tp,b,ild) and HVDCPoles(tp,br)
-                  and HVDClinkSendingBus(tp,br,b) }, branchCapacity(tp,br) ] ;
+    = Sum[ (b,br,fd) $ { BusIsland(tp,b,ild) and HVDCPoles(tp,br)
+                     and HVDClinkSendingBus(tp,br,b)
+                     and ( ord(fd) = 1 )
+                       }, branchCapacity(tp,br,fd) ] ;
 
 HVDCMax(tp,ild)
     = Min( biPoleCapacity(tp,ild), Sum[ br, monoPoleCapacity(tp,ild,br) ] ) ;
@@ -1296,9 +1333,10 @@ $ontext
 $offtext
 if (inputGDXGDate >= jdate(2016,11,22),
       HVDCCapacity(tp,ild)
-          = Sum[ (b,br) $ { BusIsland(tp,b,ild) and HVDCPoles(tp,br)
-                        and HVDClinkSendingBus(tp,br,b)
-                          }, branchCapacity(tp,br) ] ;
+          = Sum[ (b,br,fd) $ { BusIsland(tp,b,ild) and HVDCPoles(tp,br)
+                           and HVDClinkSendingBus(tp,br,b)
+                           and ( ord(fd) = 1 )
+                             }, branchCapacity(tp,br,fd) ] ;
 
       numberOfPoles(tp,ild)
           = Sum[ (b,br) $ { BusIsland(tp,b,ild) and HVDCPoles(tp,br)
@@ -1316,16 +1354,18 @@ if (inputGDXGDate >= jdate(2016,11,22),
           = Sum[ br $ monoPoleCapacity(tp,ild,br), branchResistance(tp,br) ] ;
 else
     HVDCCapacity(tp,ild)
-        = Sum[ (br,b,b1) $ { (i_tradePeriodHVDCBranch(tp,br) = 1)
-                      and i_tradePeriodBusIsland(tp,b,ild)
-                      and i_tradePeriodBranchDefn(tp,br,b,b1)
-                        }, i_tradePeriodBranchCapacity(tp,br) ] ;
+        = Sum[ (br,b,b1,fd) $ { (i_tradePeriodHVDCBranch(tp,br) = 1)
+                            and i_tradePeriodBusIsland(tp,b,ild)
+                            and i_tradePeriodBranchDefn(tp,br,b,b1)
+                            and ( ord(fd) = 1 )
+                              }, i_tradePeriodBranchCapacityDirected(tp,br,fd) ] ;
 
     numberOfPoles(tp,ild)
         =Sum[ (br,b,b1) $ { (i_tradePeriodHVDCBranch(tp,br) = 1)
                       and i_tradePeriodBusIsland(tp,b,ild)
                       and i_tradePeriodBranchDefn(tp,br,b,b1)
-                      and i_tradePeriodBranchCapacity(tp,br)
+                      and sum[ fd $ ( ord(fd) = 1 )
+                             , i_tradePeriodBranchCapacityDirected(tp,br,fd) ]
                         }, 1 ] ;
 
     HVDCResistance(tp,ild)
@@ -1341,7 +1381,8 @@ else
               $ { (i_tradePeriodHVDCBranch(tp,br) = 1)
               and i_tradePeriodBusIsland(tp,b,ild)
               and i_tradePeriodBranchDefn(tp,br,b,b1)
-              and i_tradePeriodBranchCapacity(tp,br)
+              and sum[ fd $ ( ord(fd) = 1 )
+                             , i_tradePeriodBranchCapacityDirected(tp,br,fd) ]
               and (ord(i_branchParameter) = 1)
                 }, i_tradePeriodBranchParameter(tp,br,i_branchParameter)
               ] / HVDCResistance(tp,ild) ;
@@ -1913,7 +1954,8 @@ $Ifi %opMode%=='DPS' $include "Demand\vSPDSolveDPS_2.gms"
 
 *   Ensure that the weighting factor value is zero for AC branches and for
 *   invalid loss segments on HVDC links
-    LAMBDA.fx(HVDClink,bp)  $ (not validLossSegment(HVDClink,bp)) = 0 ;
+    LAMBDA.fx(HVDClink,bp)
+        $ ( sum[fd $ validLossSegment(HVDClink,bp,fd),1] = 0 ) = 0 ;
     LAMBDA.fx(currTP,br,bp) $ (not HVDClink(currTP,br)) = 0 ;
 
 *======= HVDC TRANSMISSION EQUATIONS END =======================================
@@ -1930,10 +1972,10 @@ $Ifi %opMode%=='DPS' $include "Demand\vSPDSolveDPS_2.gms"
 *   Ensure directed block flow and loss block variables are zero for
 *   non-AC branches and invalid loss segments on AC branches
    ACBRANCHFLOWBLOCKDIRECTED.fx(currTP,br,los,fd)
-       $ { not(ACbranch(currTP,br) and validLossSegment(currTP,br,los)) } = 0 ;
+       $ { not(ACbranch(currTP,br) and validLossSegment(currTP,br,los,fd)) } = 0 ;
 
    ACBRANCHLOSSESBLOCKDIRECTED.fx(currTP,br,los,fd)
-       $ { not(ACbranch(currTP,br) and validLossSegment(currTP,br,los)) } = 0 ;
+       $ { not(ACbranch(currTP,br) and validLossSegment(currTP,br,los,fd)) } = 0 ;
 
 
 *   Constraint 3.3.1.10 - Ensure that the bus voltage angle for the buses
@@ -2133,7 +2175,9 @@ $offtext
 *       Ensure that the weighting factor value is zero for AC branches
 *       and for invalid loss segments on HVDC links
         LAMBDAINTEGER.fx(branch(currTP,br),bp)
-            $ { ACbranch(branch) or (not validLossSegment(branch,bp)) } = 0 ;
+            $ { ACbranch(branch)
+            or ( sum[fd $ validLossSegment(branch,bp,fd),1 ] = 0 )
+              } = 0 ;
 
 *       Fix the lambda integer variable to zero for invalid branches
         LAMBDAINTEGER.fx(currTP,br,bp) $ (not branch(currTP,br)) = 0 ;
@@ -2195,7 +2239,9 @@ $offtext
 *       Ensure that the weighting factor value is zero for AC branches
 *       and for invalid loss segments on HVDC links
         LAMBDAINTEGER.fx(branch(currTP,br),bp)
-            $ {ACbranch(branch) or (not  validLossSegment(branch,bp)) } = 0 ;
+            $ { ACbranch(branch)
+            or ( sum[fd $ validLossSegment(branch,bp,fd),1 ] = 0 )
+              } = 0 ;
 
 *       Fix the lambda integer variable to zero for invalid branches
         LAMBDAINTEGER.fx(currTP,br,bp) $ (not branch(currTP,br)) = 0 ;
@@ -2216,9 +2262,9 @@ $offtext
 
 *       Post a progress message for use by EMI.
         if(ModelSolved = 1,
-
-*           TN - Replacing invalid prices after SOS1 - Flag to show the period that required SOS1 solve
-            vSPD_SOS1_Solve(currTP)  = yes;
+		
+*           TN - Replacing invalid prices after SOS1 - Flag to show the period that required SOS1 solve	
+            vSPD_SOS1_Solve(currTP)  = yes;	
 
             loop(currTP,
                 putclose runlog 'The case: %vSPDinputData% (' currTP.tl ') '
@@ -2396,22 +2442,24 @@ $offtext
                   } = 1 ;
 
 *           Check if there are non-physical losses on HVDC links
-            ManualBranchSegmentMWFlow(LossBranch(HVDClink(currTP,br)),los)
+            ManualBranchSegmentMWFlow(LossBranch(HVDClink(currTP,br)),los,fd)
                 $ { ( ord(los) <= branchLossBlocks(HVDClink) )
-                and validLossSegment(currTP,br,los) }
+                and validLossSegment(currTP,br,los,fd) }
                 = Min[ Max( 0,
                             [ abs(HVDCLINKFLOW.l(HVDClink))
-                            - [LossSegmentMW(HVDClink,los-1) $ (ord(los) > 1)]
+                            - [LossSegmentMW(HVDClink,los-1,fd) $ (ord(los) > 1)]
                             ]
                           ),
-                       ( LossSegmentMW(HVDClink,los)
-                       - [LossSegmentMW(HVDClink,los-1) $ (ord(los) > 1)]
+                       ( LossSegmentMW(HVDClink,los,fd)
+                       - [LossSegmentMW(HVDClink,los-1,fd) $ (ord(los) > 1)]
                        )
                      ] ;
 
             ManualLossCalculation(LossBranch(HVDClink(currTP,br)))
-                = sum[ los, LossSegmentFactor(HVDClink,los)
-                          * ManualBranchSegmentMWFlow(HVDClink,los) ] ;
+                = sum[ (los,fd) $ validLossSegment(currTP,br,los,fd)
+                                , LossSegmentFactor(HVDClink,los,fd)
+                                * ManualBranchSegmentMWFlow(HVDClink,los,fd)
+                     ] ;
 
             NonPhysicalLossExist(LossBranch(HVDClink(currTP,br)))
                 $ { abs( HVDCLINKLOSSES.l(HVDClink)
@@ -2624,82 +2672,83 @@ $offtext
 
 * End Check for disconnected nodes and adjust prices accordingly
 
-* TN - Replacing invalid prices after SOS1
-*   6f0. Replacing invalid prices after SOS1 (6.1.3)----------------------------
-    if ( vSPD_SOS1_Solve(tp),
-         busSOSinvalid(tp,b)
-           = 1 $ { [ ( busPrice(tp,b) = 0 )
-                    or ( busPrice(tp,b) > 0.9 * deficitBusGenerationPenalty )
-                    or ( busPrice(tp,b) < -0.9 * surplusBusGenerationPenalty )
-                     ]
-                 and bus(tp,b)
-                 and [ not busDisconnected(tp,b) ]
-                 and [ busLoad(tp,b) = 0 ]
-                 and [ busGeneration(tp,b) = 0 ]
-                 and [ sum[(br,fd)
-                          $ { BranchBusConnect(tp,br,b) and branch(tp,br) }
-                          , ACBRANCHFLOWDIRECTED.l(tp,br,fd)
-                          ] = 0
-                     ]
-                 and [ sum[ br
-                          $ { BranchBusConnect(tp,br,b) and branch(tp,br) }
-                          , 1
-                          ] > 0
-                     ]
-                   };
-        numberofbusSOSinvalid(tp) = 2*sum[b, busSOSinvalid(tp,b)];
+* TN - Replacing invalid prices after SOS1	
+*   6f0. Replacing invalid prices after SOS1 (6.1.3)----------------------------	
+    if ( vSPD_SOS1_Solve(tp),	
+         busSOSinvalid(tp,b)	
+           = 1 $ { [ ( busPrice(tp,b) = 0 )	
+                    or ( busPrice(tp,b) > 0.9 * deficitBusGenerationPenalty )	
+                    or ( busPrice(tp,b) < -0.9 * surplusBusGenerationPenalty )	
+                     ]	
+                 and bus(tp,b)	
+                 and [ not busDisconnected(tp,b) ]	
+*                 and [ busLoad(tp,b) = 0 ]	
+*                 and [ busGeneration(tp,b) = 0 ]
+                 and [ busLoad(tp,b) = busGeneration(tp,b) ]	
+                 and [ sum[(br,fd)	
+                          $ { BranchBusConnect(tp,br,b) and branch(tp,br) }	
+                          , ACBRANCHFLOWDIRECTED.l(tp,br,fd)	
+                          ] = 0	
+                     ]	
+                 and [ sum[ br	
+                          $ { BranchBusConnect(tp,br,b) and branch(tp,br) }	
+                          , 1	
+                          ] > 0	
+                     ]	
+                   };	
+        numberofbusSOSinvalid(tp) = 2*sum[b, busSOSinvalid(tp,b)];	
         While ( sum[b, busSOSinvalid(tp,b)] < numberofbusSOSinvalid(tp) ,
-
-            numberofbusSOSinvalid(tp) = sum[b, busSOSinvalid(tp,b)];
-
-            busPrice(tp,b)
-              $ { busSOSinvalid(tp,b)
-              and ( sum[ b1 $ { [ not busSOSinvalid(tp,b1) ]
-                            and sum[ br $ { branch(tp,br)
-                                        and BranchBusConnect(tp,br,b)
-                                        and BranchBusConnect(tp,br,b1)
-                                          }, 1
-                                   ]
-                             }, 1
-                       ] > 0
-                  )
-                }
-               = sum[ b1 $ { [ not busSOSinvalid(tp,b1) ]
-                         and sum[ br $ { branch(tp,br)
-                                        and BranchBusConnect(tp,br,b)
-                                        and BranchBusConnect(tp,br,b1)
-                                          }, 1 ]
-                           }, busPrice(tp,b1)
-                    ]
-               / sum[ b1 $ { [ not busSOSinvalid(tp,b1) ]
-                         and sum[ br $ { branch(tp,br)
-                                        and BranchBusConnect(tp,br,b)
-                                        and BranchBusConnect(tp,br,b1)
-                                          }, 1 ]
-                          }, 1
-                    ];
-              busSOSinvalid(tp,b)
-                = 1 $ { [ ( busPrice(tp,b) = 0 )
-                         or ( busPrice(tp,b) > 0.9 * deficitBusGenerationPenalty )
-                         or ( busPrice(tp,b) < -0.9 * surplusBusGenerationPenalty )
-                          ]
-                      and bus(tp,b)
-                      and [ not busDisconnected(tp,b) ]
-                      and [ busLoad(tp,b) = 0 ]
-                      and [ busGeneration(tp,b) = 0 ]
-                      and [ sum[(br,fd)
-                          $ { BranchBusConnect(tp,br,b) and branch(tp,br) }
-                          , ACBRANCHFLOWDIRECTED.l(tp,br,fd)
-                          ] = 0
-                     ]
-                 and [ sum[ br
-                          $ { BranchBusConnect(tp,br,b) and branch(tp,br) }
-                          , 1
-                          ] > 0
-                     ]
-                        };
-         );
-    );
+            numberofbusSOSinvalid(tp) = sum[b, busSOSinvalid(tp,b)];	
+            busPrice(tp,b)	
+              $ { busSOSinvalid(tp,b)	
+              and ( sum[ b1 $ { [ not busSOSinvalid(tp,b1) ]	
+                            and sum[ br $ { branch(tp,br)	
+                                        and BranchBusConnect(tp,br,b)	
+                                        and BranchBusConnect(tp,br,b1)	
+                                          }, 1	
+                                   ]	
+                             }, 1	
+                       ] > 0	
+                  )	
+                }	
+              = sum[ b1 $ { [ not busSOSinvalid(tp,b1) ]	
+                        and sum[ br $ { branch(tp,br)	
+                                    and BranchBusConnect(tp,br,b)	
+                                    and BranchBusConnect(tp,br,b1)	
+                                      }, 1 ]	
+                          }, busPrice(tp,b1)	
+                   ]	
+              / sum[ b1 $ { [ not busSOSinvalid(tp,b1) ]	
+                        and sum[ br $ { branch(tp,br)	
+                                    and BranchBusConnect(tp,br,b)	
+                                    and BranchBusConnect(tp,br,b1)	
+                                      }, 1 ]	
+                          }, 1	
+                   ];
+                    
+            busSOSinvalid(tp,b)	
+              = 1 $ { [ ( busPrice(tp,b) = 0 )	
+                     or ( busPrice(tp,b) > 0.9 * deficitBusGenerationPenalty )	
+                     or ( busPrice(tp,b) < -0.9 * surplusBusGenerationPenalty )	
+                      ]	
+                  and bus(tp,b)	
+                  and [ not busDisconnected(tp,b) ]	
+*                  and [ busLoad(tp,b) = 0 ]	
+*                  and [ busGeneration(tp,b) = 0 ]
+                  and [ busLoad(tp,b) = busGeneration(tp,b) ]	
+                  and [ sum[(br,fd)	
+                          $ { BranchBusConnect(tp,br,b) and branch(tp,br) }	
+                          , ACBRANCHFLOWDIRECTED.l(tp,br,fd)	
+                           ] = 0	
+                      ]	
+                  and [ sum[ br	
+                           $ { BranchBusConnect(tp,br,b) and branch(tp,br) }	
+                           , 1	
+                           ] > 0	
+                      ]	
+                    };	
+         );	
+    );	
 *   End Replacing invalid prices after SOS1 (6.1.3) ----------------------------
 
 
@@ -2866,7 +2915,13 @@ $offtext
             = HVDClinkMaximumFlow.m(currTP,br) ;
 
         o_branchCapacity_TP(dt,br) $ branch(currTP,br)
-            = i_tradePeriodBranchCapacity(currTP,br) ;
+            = sum[ fd $ ( ord(fd) = 1 )
+                      , i_tradePeriodBranchCapacityDirected(currTP,br,fd)
+                 ] $  { o_branchFlow_TP(dt,br) >= 0 }
+            + sum[ fd $ ( ord(fd) = 2 )
+                      , i_tradePeriodBranchCapacityDirected(currTP,br,fd)
+                 ] $  { o_branchFlow_TP(dt,br) < 0 } ;
+
 
 *       Offer output
         o_offerEnergyBlock_TP(dt,o,trdBlk)
@@ -3081,31 +3136,59 @@ $offtext
         o_ACbusAngle(dt,b) = ACNODEANGLE.l(currTP,b) ;
 
 *       Check if there are non-physical losses on AC branches
-        ManualBranchSegmentMWFlow(LossBranch(branch(currTP,br)),los)
-                $ { ( ord(los) <= branchLossBlocks(branch) )
-                and validLossSegment(branch,los) }
+        ManualBranchSegmentMWFlow(LossBranch(ACbranch(currTP,br)),los,fd)
+                $ { ( ord(los) <= branchLossBlocks(ACbranch) )
+                and validLossSegment(ACbranch,los,fd)
+                and ( ACBRANCHFLOWDIRECTED.l(ACbranch,fd) > 0 )
+                  }
                 = Min[ Max( 0,
                             [ abs(o_branchFlow_TP(dt,br))
-                            - [LossSegmentMW(branch,los-1) $ (ord(los) > 1)]
+                            - [LossSegmentMW(ACbranch,los-1,fd) $ (ord(los) > 1)]
                             ]
                           ),
-                       ( LossSegmentMW(branch,los)
-                       - [LossSegmentMW(branch,los-1) $ (ord(los) > 1)]
+                       ( LossSegmentMW(ACbranch,los,fd)
+                       - [LossSegmentMW(ACbranch,los-1,fd) $ (ord(los) > 1)]
+                       )
+                     ] ;
+
+        ManualBranchSegmentMWFlow(LossBranch(HVDClink(currTP,br)),los,fd)
+                $ { ( ord(los) <= branchLossBlocks(HVDClink) )
+                and validLossSegment(HVDClink,los,fd) and ( ord(fd) = 1 )
+                  }
+                = Min[ Max( 0,
+                            [ abs(o_branchFlow_TP(dt,br))
+                            - [LossSegmentMW(HVDClink,los-1,fd) $ (ord(los) > 1)]
+                            ]
+                          ),
+                       ( LossSegmentMW(HVDClink,los,fd)
+                       - [LossSegmentMW(HVDClink,los-1,fd) $ (ord(los) > 1)]
                        )
                      ] ;
 
         ManualLossCalculation(LossBranch(branch(currTP,br)))
-            = sum[ los, LossSegmentFactor(branch,los)
-                      * ManualBranchSegmentMWFlow(branch,los) ] ;
+            = sum[ (los,fd), LossSegmentFactor(branch,los,fd)
+                           * ManualBranchSegmentMWFlow(branch,los,fd) ] ;
 
         o_nonPhysicalLoss(dt,br) = o_branchDynamicLoss_TP(dt,br)
                                  - ManualLossCalculation(currTP,br) ;
 
-        o_lossSegmentBreakPoint(dt,br,los) $ validLossSegment(currTP,br,los)
-                                           = LossSegmentMW(currTP,br,los) ;
+        o_lossSegmentBreakPoint(dt,br,los)
+            = sum [ fd $ { validLossSegment(currTP,br,los,fd)
+                       and (ord(fd) = 1)
+                         }, LossSegmentMW(currTP,br,los,fd) ] $ { o_branchFlow_TP(dt,br) >= 0 }
+            + sum [ fd $ { validLossSegment(currTP,br,los,fd)
+                       and (ord(fd) = 2)
+                         }, LossSegmentMW(currTP,br,los,fd) ] $ { o_branchFlow_TP(dt,br) < 0 }
+        ;
 
-        o_lossSegmentFactor(dt,br,los) $ validLossSegment(currTP,br,los)
-                                       = LossSegmentFactor(currTP,br,los) ;
+        o_lossSegmentFactor(dt,br,los)
+            = sum [ fd $ { validLossSegment(currTP,br,los,fd)
+                       and (ord(fd) = 1)
+                         }, LossSegmentFactor(currTP,br,los,fd) ] $ { o_branchFlow_TP(dt,br) >= 0 }
+            + sum [ fd $ { validLossSegment(currTP,br,los,fd)
+                       and (ord(fd) = 2)
+                         }, LossSegmentFactor(currTP,br,los,fd) ] $ { o_branchFlow_TP(dt,br) < 0 }
+        ;
 
         o_busIsland_TP(dt,b,ild) $ busIsland(currTP,b,ild) = yes ;
 

--- a/Programs/vSPDsolve.gms
+++ b/Programs/vSPDsolve.gms
@@ -2119,6 +2119,7 @@ $offtext
                             and ( vSPD_NMIR.solvestat = 1 ) } ;
         else
             option bratio = 1 ;
+            vSPD.Optfile = 1 ;
             vSPD.reslim = LPTimeLimit ;
             vSPD.iterlim = LPIterationLimit ;
             solve vSPD using lp maximizing NETBENEFIT ;
@@ -2348,6 +2349,7 @@ $offtext
                             and ( vSPD_NMIR.solvestat = 1 ) } ;
         else
             option bratio = 1 ;
+            vSPD.Optfile = 1 ;
             vSPD.reslim = LPTimeLimit ;
             vSPD.iterlim = LPIterationLimit ;
             solve vSPD using lp maximizing NETBENEFIT ;


### PR DESCRIPTION
We have been seeing regular out of memory failures solving recent GDX files in FTR mode. These occur while gams is executing a solve (using cplex) which doesn't initialize itself from the cplex options file (unlike other solves typically do). It should be preferable for all solve invocations to be configured from the same cplex options file in case there are particular options specified which help the solve to succeed given the available hardware.

Below is a sample of the relevant section of the gams output during a failing solve.

IBM ILOG CPLEX   26.1.0 rf2b37b9 Released Feb 02, 2019 WEI x86 64bit/MS Window
--- GAMS/Cplex licensed for continuous and discrete problems.
Cplex 12.8.0.0

Reading data...
Starting Cplex...
Space for names approximately 724.62 Mb
Use option 'names no' to turn use of names off
CPXPARAM_Advance                                 0
CPXPARAM_Simplex_Limits_Iterations               2000000000
CPXPARAM_TimeLimit                               3600
CPXPARAM_Threads                                 1
CPXPARAM_Parallel                                1
CPXPARAM_Tune_TimeLimit                          720
Presolve time = 10.33 sec. (5148.36 ticks)
Insufficient memory for presolve.
Compressing row and column files.
CPLEX Error  1001: Out of memory.
LP status(0): 
Cplex Time: 17.89sec (det. 8123.87 ticks)
*** CPLEX Error  1001: Out of memory.
